### PR TITLE
vcs detection

### DIFF
--- a/src/Local_Development/Base.php
+++ b/src/Local_Development/Base.php
@@ -93,7 +93,7 @@ class Base {
 		if ( ( ! empty( self::$plugins ) && array_key_exists( $file, self::$plugins ) ) ||
 			( ! empty( self::$themes ) && array_key_exists( $file, self::$themes ) )
 		) {
-			$links[] = '<strong>' . self::$message . '</strong>';
+			$links[] = '<strong style="color:red; font-weight:700;">' . self::$message . '</strong>';
 			add_action( "after_plugin_row_{$file}", [ $this, 'remove_update_row' ], 15, 1 );
 			add_action( "after_theme_row_{$file}", [ $this, 'remove_update_row' ], 15, 1 );
 		}
@@ -131,7 +131,7 @@ class Base {
 		foreach ( $prepared_themes as $theme ) {
 			if ( array_key_exists( $theme['id'], (array) self::$themes ) ) {
 				$message  = wp_get_theme( $theme['id'] )->get( 'Description' );
-				$message .= '<p><strong>' . self::$message . '</strong></p>';
+				$message .= '<p><strong style="color:red; font-weight:700;">' . self::$message . '</strong></p>';
 
 				$prepared_themes[ $theme['id'] ]['description'] = $message;
 				unset( $prepared_themes[ $theme['id'] ]['actions']['delete'] );

--- a/src/Local_Development/Extras.php
+++ b/src/Local_Development/Extras.php
@@ -105,21 +105,6 @@ class Extras extends Settings {
 				]
 			);
 		}
-
-		if( in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ] ) ) {
-			add_settings_field(
-				'adminbar_visual_feedback',
-				null,
-				[ $this, 'token_callback_checkbox' ],
-				'local_dev_extras',
-				'local_dev_extras',
-				[
-					'id'   => 'disable_admin_bar_visual_feedback',
-					'type' => 'extras',
-					'name' => esc_html( 'Disable custom Admin Bar styles for Localhost Server', 'local-development' ),
-				]
-			);
-		}
 	}
 
 	/**
@@ -160,10 +145,6 @@ class Extras extends Settings {
 		if ( isset( self::$options['extras']['bypass_fatal_error_handler'] ) ) {
 			add_filter( 'wp_fatal_error_handler_enabled', '__return_false' );
 		}
-		if ( ! isset( static::$options['extras']['disable_admin_bar_visual_feedback'] ) ) {
-			add_action( 'admin_head', [ $this, 'custom_local_admin_bar_css' ] ); // on backend area.
-			add_action( 'wp_head', [ $this, 'custom_local_admin_bar_css' ] ); // on frontend area.
-		}
 	}
 
 	/**
@@ -198,44 +179,5 @@ class Extras extends Settings {
 			10,
 			2
 		);
-	}
-
-	/**
-	 * Add custom admin bar colors while running a localhost server.
-	 *
-	 * @return void
-	 */
-	function custom_local_admin_bar_css() {
-
-		if ( is_admin_bar_showing() ) { ?>
-
-			<style type="text/css">
-
-				#wpadminbar #wp-admin-bar-site-name > .ab-item::after {
-					content: " - localhost";
-					font-weight: 800;
-					font-family: Monospace;
-					color: #fff;
-				}
-
-				#wpadminbar #wp-admin-bar-site-name > .ab-item {
-					background-color: #008000;
-					color: #ff0;
-				}
-
-				#wpadminbar #wp-admin-bar-site-name > .ab-item::before {
-					background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiB3aWR0aD0iMTQiIGhlaWdodD0iMTYiIHN0eWxlPSItbXMtdHJhbnNmb3JtOnJvdGF0ZSgzNjBkZWcpOy13ZWJraXQtdHJhbnNmb3JtOnJvdGF0ZSgzNjBkZWcpO3RyYW5zZm9ybTpyb3RhdGUoMzYwZGVnKSI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNOS41IDNMOCA0LjUgMTEuNSA4IDggMTEuNSA5LjUgMTMgMTQgOCA5LjUgM3ptLTUgMEwwIDhsNC41IDVMNiAxMS41IDIuNSA4IDYgNC41IDQuNSAzeiIgZmlsbD0iI2ZmMCIvPjwvc3ZnPg==) !important;
-					background-size: 100%;
-					background-position: center center;
-					background-repeat: no-repeat;
-					content: " " !important;
-					display: block;
-					width: 16px;
-					height: 21px;
-				}
-
-			</style>
-
-		<?php }
 	}
 }

--- a/src/Local_Development/Extras.php
+++ b/src/Local_Development/Extras.php
@@ -105,6 +105,21 @@ class Extras extends Settings {
 				]
 			);
 		}
+
+		if( in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ] ) ) {
+			add_settings_field(
+				'adminbar_visual_feedback',
+				null,
+				[ $this, 'token_callback_checkbox' ],
+				'local_dev_extras',
+				'local_dev_extras',
+				[
+					'id'   => 'disable_admin_bar_visual_feedback',
+					'type' => 'extras',
+					'name' => esc_html( 'Disable custom Admin Bar styles for Localhost Server', 'local-development' ),
+				]
+			);
+		}
 	}
 
 	/**
@@ -145,6 +160,10 @@ class Extras extends Settings {
 		if ( isset( self::$options['extras']['bypass_fatal_error_handler'] ) ) {
 			add_filter( 'wp_fatal_error_handler_enabled', '__return_false' );
 		}
+		if ( ! isset( static::$options['extras']['disable_admin_bar_visual_feedback'] ) ) {
+			add_action( 'admin_head', [ $this, 'custom_local_admin_bar_css' ] ); // on backend area.
+			add_action( 'wp_head', [ $this, 'custom_local_admin_bar_css' ] ); // on frontend area.
+		}
 	}
 
 	/**
@@ -179,5 +198,44 @@ class Extras extends Settings {
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Add custom admin bar colors while running a localhost server.
+	 *
+	 * @return void
+	 */
+	function custom_local_admin_bar_css() {
+
+		if ( is_admin_bar_showing() ) { ?>
+
+			<style type="text/css">
+
+				#wpadminbar #wp-admin-bar-site-name > .ab-item::after {
+					content: " - localhost";
+					font-weight: 800;
+					font-family: Monospace;
+					color: #fff;
+				}
+
+				#wpadminbar #wp-admin-bar-site-name > .ab-item {
+					background-color: #008000;
+					color: #ff0;
+				}
+
+				#wpadminbar #wp-admin-bar-site-name > .ab-item::before {
+					background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGFyaWEtaGlkZGVuPSJ0cnVlIiB3aWR0aD0iMTQiIGhlaWdodD0iMTYiIHN0eWxlPSItbXMtdHJhbnNmb3JtOnJvdGF0ZSgzNjBkZWcpOy13ZWJraXQtdHJhbnNmb3JtOnJvdGF0ZSgzNjBkZWcpO3RyYW5zZm9ybTpyb3RhdGUoMzYwZGVnKSI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNOS41IDNMOCA0LjUgMTEuNSA4IDggMTEuNSA5LjUgMTMgMTQgOCA5LjUgM3ptLTUgMEwwIDhsNC41IDVMNiAxMS41IDIuNSA4IDYgNC41IDQuNSAzeiIgZmlsbD0iI2ZmMCIvPjwvc3ZnPg==) !important;
+					background-size: 100%;
+					background-position: center center;
+					background-repeat: no-repeat;
+					content: " " !important;
+					display: block;
+					width: 16px;
+					height: 21px;
+				}
+
+			</style>
+
+		<?php }
 	}
 }

--- a/src/Local_Development/Init.php
+++ b/src/Local_Development/Init.php
@@ -51,22 +51,25 @@ class Init {
 	 * Get VCS checkouts and add automatically to config.
 	 */
 	private function get_vcs_checkouts() {
-		if ( ! class_exists( '\WP_Automatic_Updater' ) ) {
-			return;
-		}
 		$config         = get_site_option( 'local_development', [] );
-		$updater        = new \WP_Automatic_Updater();
 		$plugins_themes = Singleton::get_instance( 'Settings', $this )->init();
+
+		$vcs_dirs   = array( '.svn', '.git', '.hg', '.bzr' );
 
 		foreach ( [ 'plugins', 'themes' ] as $type ) {
 			foreach ( array_keys( $plugins_themes[ $type ] ) as $file ) {
 				$wp_path  = 'plugins' === $type ? wp_normalize_path( WP_PLUGIN_DIR ) : wp_normalize_path( get_theme_root() );
 				$slug     = 'plugins' === $type ? dirname( $file ) : $file;
 				$filepath = "$wp_path/$slug";
-				$is_vcs   = $updater->is_vcs_checkout( $filepath );
-				if ( $is_vcs ) {
-					$config[ $type ][ $file ] = '1';
+
+				foreach ( $vcs_dirs as $vcs_dir ) {
+					$is_vcs = @is_dir( rtrim( $filepath, '\\/' ) . "/$vcs_dir" );
+					if ( $is_vcs ) {
+						$config[ $type ][ $file ] = '-1';
+						break;
+					}
 				}
+
 			}
 		}
 

--- a/src/Local_Development/Init.php
+++ b/src/Local_Development/Init.php
@@ -60,10 +60,10 @@ class Init {
 			foreach ( array_keys( $plugins_themes[ $type ] ) as $file ) {
 				$wp_path  = 'plugins' === $type ? wp_normalize_path( WP_PLUGIN_DIR ) : wp_normalize_path( get_theme_root() );
 				$slug     = 'plugins' === $type ? dirname( $file ) : $file;
-				$filepath = "$wp_path/$slug";
+				$filepath = untrailingslashit( "$wp_path/$slug" );
 
 				foreach ( $vcs_dirs as $vcs_dir ) {
-					$is_vcs = @is_dir( rtrim( $filepath, '\\/' ) . "/$vcs_dir" );
+					$is_vcs = @is_dir( "$filepath/$vcs_dir" );
 					if ( $is_vcs ) {
 						$config[ $type ][ $file ] = '-1';
 						break;

--- a/src/Local_Development/Settings.php
+++ b/src/Local_Development/Settings.php
@@ -224,7 +224,7 @@ class Settings {
 		$checked = isset( self::$options[ $args['type'] ][ $args['id'] ] ) ? esc_attr( self::$options[ $args['type'] ][ $args['id'] ] ) : null;
 		?>
 		<label for="<?php esc_attr_e( $args['id'] ); ?>">
-			<input type="checkbox" name="local_dev[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', $checked, true ); ?> >
+			<input type="checkbox" name="local_dev[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', abs( $checked ), true ); ?> <?php disabled( '-1', $checked, true ); ?> >
 			<?php esc_html_e( $args['name'] ); ?>
 		</label>
 		<?php


### PR DESCRIPTION
In response to: https://github.com/afragen/local-development/issues/4, [`WP_Automatic_Updater::is_vcs_checkout`](https://developer.wordpress.org/reference/classes/wp_automatic_updater/is_vcs_checkout/) is a tree walker function.

_.. it breaks all if a parent folder is under vcs .._

---

In particular, in this version of mine:
- automatically added checkboxes are disabled by default
- a visual feedback is added to the admin bar when working on localhost
- increased visibility of the "in local development" label