### PR TITLE
Add context to menu item to separate from plugin name string

### DIFF
--- a/src/Local_Development/Settings.php
+++ b/src/Local_Development/Settings.php
@@ -135,7 +135,7 @@ class Settings {
 		add_submenu_page(
 			$parent,
 			esc_html__( 'Local Development Settings', 'local-development' ),
-			esc_html__( 'Local Development', 'local-development' ),
+			esc_html_x( 'Local Development', 'Menu item', 'local-development' ),
 			$capability,
 			'local-development',
 			[ $this, 'create_admin_page' ]


### PR DESCRIPTION
This allows the translation of the string without translating the plugin name.